### PR TITLE
Blessed xterm fixes

### DIFF
--- a/blessed-xterm.js
+++ b/blessed-xterm.js
@@ -23,7 +23,6 @@
 */
 
 /*  external requirements  */
-const clone   = require("clone")
 const blessed = require("blessed")
 const Pty     = require("node-pty")
 const jsdom   = require("jsdom")
@@ -41,9 +40,6 @@ const XTermJS = require("xterm")
 class XTerm extends blessed.Box {
     /*  construct the API class  */
     constructor (options = {}) {
-        /*  clone options or all widget instances will show
-            at least the same style, etc.  */
-        options = clone(options)
 
         /*  disable the special "scrollable" feature of Blessed's Element
             which would use a ScrolledBox instead of a Box under the surface  */

--- a/blessed-xterm.js
+++ b/blessed-xterm.js
@@ -28,10 +28,16 @@ const Pty     = require("node-pty")
 const jsdom   = require("jsdom")
 
 /*  CRUEL HACK: xterm.js accesses the global "window", so we have to emulate this environment  */
-var dom = new jsdom.JSDOM()
-global.window = dom.window
-global.window.requestAnimationFrame = (cb) => setTimeout(cb, 0)
-var document = dom.window.document
+var document;
+if (typeof window !== 'undefined') {
+    window.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+    document = window.document;
+} else {
+    var dom = new jsdom.JSDOM();
+    global.window = dom.window;
+    global.window.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+    document = dom.window.document;
+}
 
 /*  load xterm.js  */
 const XTermJS = require("xterm")

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     },
     "dependencies" : {
         "babel-runtime":                             "~6.26.0",
-        "clone":                                     "~2.1.1",
         "blessed":                                   "~0.1.81",
         "jsdom":                                     "~11.5.1",
         "xterm":                                     "~2.8.1",


### PR DESCRIPTION
In this PR I propose to 

1.  remove the cloning of the options as it may result in [errors](https://github.com/pvorb/clone/issues/82) when using the parent:screen option.
2. make blessed-xterm work in the browser as the global.window is read only.
 

Thanks!